### PR TITLE
feat: switch from active BLE scanning to passive HA bluetooth callbacks

### DIFF
--- a/custom_components/yunmai_scale/__init__.py
+++ b/custom_components/yunmai_scale/__init__.py
@@ -1,17 +1,19 @@
 """The Yunmai Scale integration."""
 
-import asyncio
 import logging
-from datetime import timedelta
 from typing import Any
 
-import voluptuous as vol
-from bleak import BleakError, BleakScanner
+from homeassistant.components.bluetooth import (
+    BluetoothCallbackMatcher,
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+    async_register_callback,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_AGE,
@@ -19,8 +21,7 @@ from .const import (
     CONF_HEIGHT,
     CONF_IS_ACTIVE,
     DOMAIN,
-    SCAN_INTERVAL,
-    SERVICE_UUID_PREFIX,
+    SERVICE_UUID,
 )
 from .parse_data import process_data
 
@@ -34,9 +35,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     coordinator = YunmaiDataCoordinator(hass, entry)
-    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    entry.async_on_unload(
+        async_register_callback(
+            hass,
+            coordinator.async_handle_bluetooth_event,
+            BluetoothCallbackMatcher(service_uuid=SERVICE_UUID),
+            BluetoothScanningMode.PASSIVE,
+        )
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -64,7 +73,6 @@ class YunmaiDataCoordinator(DataUpdateCoordinator):
             CONF_IS_ACTIVE: entry.data.get(CONF_IS_ACTIVE, False),
             CONF_AGE: entry.data.get(CONF_AGE, 30),
         }
-        self._last_data = {}
         self._device_info = {
             "name": entry.data.get(CONF_NAME, "Yunmai Scale"),
             "model": "Yunmai Scale",
@@ -76,7 +84,6 @@ class YunmaiDataCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{self.mac_address}",
-            update_interval=timedelta(seconds=SCAN_INTERVAL),
         )
 
     @property
@@ -85,72 +92,43 @@ class YunmaiDataCoordinator(DataUpdateCoordinator):
         return self._device_info
 
     async def _async_update_data(self) -> dict:
-        """Scan for BLE advertisements from Yunmai scale and process the data."""
-        try:
-            detected_data = {}
+        """No-op: data is pushed via Bluetooth callbacks."""
+        return self.data or {}
 
-            def detection_callback(device, advertisement_data):
-                """Process advertisement data."""
-                if not device or not advertisement_data:
-                    return
+    @callback
+    def async_handle_bluetooth_event(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Handle a Bluetooth event from Home Assistant."""
+        _LOGGER.debug(
+            "Received Bluetooth event from %s (change=%s)",
+            service_info.address,
+            change,
+        )
 
-                # Check for matching services
-                matching_services = {
-                    service_uuid
-                    for service_uuid in advertisement_data.service_uuids
-                    if str(service_uuid).startswith(SERVICE_UUID_PREFIX)
-                }
+        for mfr_id, mfr_data in service_info.advertisement.manufacturer_data.items():
+            # Compute MAC from manufacturer data
+            manufacturer_data_hex = (
+                mfr_id.to_bytes(2, "little").hex() + mfr_data.hex()
+            )
+            device_mac = ':'.join(
+                manufacturer_data_hex[:12].upper()[i : i + 2]
+                for i in range(10, -2, -2)
+            )
 
-                if not matching_services:
-                    return
+            if device_mac.upper() != self.mac_address.upper():
+                continue
 
-                # Check manufacturer data
-                for mfr_id, mfr_data in advertisement_data.manufacturer_data.items():
-                    # Compute MAC from manufacturer data if needed
-                    manufacturer_data_hex = (
-                        mfr_id.to_bytes(2, "little").hex() + mfr_data.hex()
-                    )
-                    device_mac = ':'.join(
-                        manufacturer_data_hex[:12].upper()[i : i + 2]
-                        for i in range(10, -2, -2)
-                    )
-
-                    if device_mac.upper() == self.mac_address.upper():
-                        data_hex = mfr_data.hex()
-                        processed_data = process_data(
-                            data_hex,
-                            self.user_info[CONF_AGE],
-                            self.user_info[CONF_GENDER],
-                            self.user_info[CONF_HEIGHT],
-                            self.user_info[CONF_IS_ACTIVE],
-                        )
-                        if processed_data:
-                            nonlocal detected_data
-                            detected_data = processed_data
-
-            scanner = BleakScanner(detection_callback=detection_callback)
-
-            # Start scanning
-            await scanner.start()
-            _LOGGER.debug("Scanning for Yunmai scale advertisements")
-
-            # Scan for a few seconds
-            await asyncio.sleep(5)
-
-            # Stop scanning
-            await scanner.stop()
-
-            # Return data if we found something
-            if detected_data:
-                self._last_data = detected_data
-                return detected_data
-
-            # Return last known data if we have it
-            if self._last_data:
-                return self._last_data
-
-            # Return empty if no data found
-            return {}
-
-        except BleakError as err:
-            raise UpdateFailed(f"Error communicating with Yunmai Scale: {err}") from err
+            data_hex = mfr_data.hex()
+            processed_data = process_data(
+                data_hex,
+                self.user_info[CONF_AGE],
+                self.user_info[CONF_GENDER],
+                self.user_info[CONF_HEIGHT],
+                self.user_info[CONF_IS_ACTIVE],
+            )
+            if processed_data:
+                self.async_set_updated_data(processed_data)
+                return

--- a/custom_components/yunmai_scale/config_flow.py
+++ b/custom_components/yunmai_scale/config_flow.py
@@ -9,6 +9,7 @@ from typing import Any
 import voluptuous as vol
 from bluetooth_data_tools import short_address
 from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 
@@ -18,7 +19,7 @@ from .const import (
     CONF_HEIGHT,
     CONF_IS_ACTIVE,
     DOMAIN,
-    SERVICE_UUID_PREFIX,
+    SERVICE_UUID,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +42,9 @@ class YunmaiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.discovered_devices = {}
         self.selected_device = None
 
-    async def async_step_bluetooth(self, discovery_info) -> FlowResult:
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> FlowResult:
         """Handle the bluetooth discovery step."""
         # Extract necessary information from discovery
         address = discovery_info.address
@@ -52,11 +55,10 @@ class YunmaiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         # Check if it's a Yunmai scale
-        is_yunmai = False
-        for service_uuid in discovery_info.advertisement.service_uuids:
-            if str(service_uuid).startswith(SERVICE_UUID_PREFIX):
-                is_yunmai = True
-                break
+        is_yunmai = any(
+            str(service_uuid).startswith(SERVICE_UUID[:8])
+            for service_uuid in discovery_info.advertisement.service_uuids
+        )
 
         if not is_yunmai:
             return self.async_abort(reason="not_yunmai_device")

--- a/custom_components/yunmai_scale/const.py
+++ b/custom_components/yunmai_scale/const.py
@@ -8,11 +8,8 @@ CONF_HEIGHT = "height"
 CONF_IS_ACTIVE = "is_active"
 CONF_AGE = "age"
 
-# Scan interval in seconds
-SCAN_INTERVAL = 10
-
 # Yunmai BLE constants
-SERVICE_UUID_PREFIX = "00001320"
+SERVICE_UUID = "00001320-0000-1000-8000-00805f9b34fb"
 
 # Sensor types
 SENSOR_WEIGHT = "weight"

--- a/custom_components/yunmai_scale/manifest.json
+++ b/custom_components/yunmai_scale/manifest.json
@@ -6,12 +6,12 @@
   ],
   "codeowners": ["@huyuwei1996"],
   "config_flow": true,
-  "dependencies": ["bluetooth_adapters"],
+  "dependencies": ["bluetooth"],
   "documentation": "https://github.com/huyuwei1996/integration_yunmai_scale",
   "domain": "yunmai_scale",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/huyuwei1996/integration_yunmai_scale/issues",
   "name": "Yunmai Scale",
-  "requirements": ["bleak>=0.22.3"],
-  "version": "0.1.0"
+  "requirements": [],
+  "version": "0.2.0"
 }

--- a/custom_components/yunmai_scale/sensor.py
+++ b/custom_components/yunmai_scale/sensor.py
@@ -178,7 +178,9 @@ class YunmaiSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        if not self.coordinator.data and self.entity_description.key != SENSOR_STATUS:
+        if not self.coordinator.data:
+            if self.entity_description.key == SENSOR_STATUS:
+                return self._previous_value or "idle"
             return self._previous_value
 
         value = self.entity_description.value_fn(self.coordinator.data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 homeassistant>=2024.12.5
-bleak>=0.22.3


### PR DESCRIPTION
Replace BleakScanner polling (5s scan every 10s) with HA bluetooth component's async_register_callback for event-driven updates. This follows the recommended Home Assistant BLE integration pattern.

- Remove bleak dependency, use homeassistant.components.bluetooth
- Register passive bluetooth callback with BluetoothCallbackMatcher
- Replace _async_update_data polling with async_handle_bluetooth_event
- Update manifest: dependencies to bluetooth, bump version to 0.2.0
- Add BluetoothServiceInfoBleak type annotation to config_flow